### PR TITLE
Correct Humidity->Relative Humidity in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Usage Example
     i2c = busio.I2C(board.SCL, board.SDA)
     hts = adafruit_hts221.HTS221(i2c)
     while True:
-        print("Humidity: %.2f percent rH" % hts.humidity)
+        print("Relative Humidity: %.2f percent rH" % hts.relative_humidity)
         print("Temperature: %.2f C" % hts.temperature)
         time.sleep(1)
 


### PR DESCRIPTION
Identified a missed wording update in the example code within the README.rst file.