### PR TITLE
Add typing, small refactoring

### DIFF
--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -85,7 +85,7 @@ class CV:
     @classmethod
     def is_valid(cls, value: int) -> bool:
         """Returns true if the given value is a member of the CV"""
-        return hasattr(cls, value)
+        return value in cls.label
 
 
 class Rate(CV):

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -72,7 +72,7 @@ class CV:
 
     @classmethod
     def add_values(
-        cls, value_tuples: Sequence[Tuple[str, int, Union[int, str]]]
+        cls, value_tuples: Sequence[Tuple[str, int, Union[int, float]]]
     ) -> None:
         """creates CV entries"""
         cls.label = {}

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -71,21 +71,18 @@ class CV:
     """struct helper"""
 
     @classmethod
-    def add_values(cls, value_tuples):
+    def add_values(cls, value_tuples: Sequence[Tuple[str, int]]) -> None:
         """creates CV entries"""
-        cls.string = {}
-        cls.lsb = {}
+        cls.contents = {}
 
         for value_tuple in value_tuples:
-            name, value, string, lsb = value_tuple
+            name, value = value_tuple
             setattr(cls, name, value)
-            cls.string[value] = string
-            cls.lsb[value] = lsb
 
     @classmethod
-    def is_valid(cls, value):
+    def is_valid(cls, value: int) -> bool:
         """Returns true if the given value is a member of the CV"""
-        return value in cls.string
+        return hasattr(cls, value)
 
 
 class Rate(CV):
@@ -111,10 +108,10 @@ class Rate(CV):
 
 Rate.add_values(
     (
-        ("ONE_SHOT", 0, 0, None),
-        ("RATE_1_HZ", 1, 1, None),
-        ("RATE_7_HZ", 2, 7, None),
-        ("RATE_12_5_HZ", 3, 12.5, None),
+        ("ONE_SHOT", 0),
+        ("RATE_1_HZ", 1),
+        ("RATE_7_HZ", 2),
+        ("RATE_12_5_HZ", 3),
     )
 )
 

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -76,12 +76,12 @@ class CV:
     ) -> None:
         """creates CV entries"""
         cls.contents = {}
-        cls.string = {}
+        cls.label = {}
 
         for value_tuple in value_tuples:
-            name, value, string = value_tuple
+            name, value, label = value_tuple
             setattr(cls, name, value)
-            cls.string[value] = string
+            cls.label[value] = label
 
     @classmethod
     def is_valid(cls, value: int) -> bool:

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -113,10 +113,7 @@ class Rate(CV):
 Rate.add_values(
     (
         ("ONE_SHOT", 0, 0),
-        (
-            "RATE_1_HZ",
-            1,
-        ),
+        ("RATE_1_HZ", 1, 1),
         ("RATE_7_HZ", 2, 7),
         ("RATE_12_5_HZ", 3, 12.5),
     )

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -34,6 +34,12 @@ from adafruit_register.i2c_struct import ROUnaryStruct
 from adafruit_register.i2c_bits import RWBits, ROBits
 from adafruit_register.i2c_bit import RWBit, ROBit
 
+try:
+    from typing import Sequence, Tuple
+    from busio import I2C
+except ImportError:
+    pass
+
 _WHO_AM_I = const(0x0F)
 
 _CTRL_REG1 = const(0x20)
@@ -170,7 +176,7 @@ class HTS221:  # pylint: disable=too-many-instance-attributes
     _h0_t0_out = ROUnaryStruct(_H0_T0_OUT, "<h")
     _h1_t0_out = ROUnaryStruct(_H1_T1_OUT, "<h")
 
-    def __init__(self, i2c_bus):
+    def __init__(self, i2c_bus: I2C) -> None:
         self.i2c_device = i2cdevice.I2CDevice(i2c_bus, _HTS221_DEFAULT_ADDRESS)
         if not self._chip_id in [_HTS221_CHIP_ID]:
             raise RuntimeError(
@@ -203,14 +209,14 @@ class HTS221:  # pylint: disable=too-many-instance-attributes
         self.calib_hum_meas_1 = self._h1_t0_out
 
     # This is the closest thing to a software reset. It re-loads the calibration values from flash
-    def _boot(self):
+    def _boot(self) -> None:
         self._boot_bit = True
         # wait for the reset to finish
         while self._boot_bit:
             pass
 
     @property
-    def relative_humidity(self):
+    def relative_humidity(self) -> float:
         """The current relative humidity measurement in %rH"""
         calibrated_value_delta = self.calib_hum_value_1 - self.calib_hum_value_0
         calibrated_measurement_delta = self.calib_hum_meas_1 - self.calib_hum_meas_0
@@ -228,7 +234,7 @@ class HTS221:  # pylint: disable=too-many-instance-attributes
         return adjusted_humidity
 
     @property
-    def temperature(self):
+    def temperature(self) -> float:
         """The current temperature measurement in degrees Celsius"""
 
         calibrated_value_delta = self.calibrated_value_1 - self.calib_temp_value_0
@@ -247,7 +253,7 @@ class HTS221:  # pylint: disable=too-many-instance-attributes
         return adjusted_temp
 
     @property
-    def data_rate(self):
+    def data_rate(self) -> int:
         """The rate at which the sensor measures :attr:`relative_humidity` and :attr:`temperature`.
         :attr:`data_rate` should be set to one of the values of :class:`adafruit_hts221.Rate`.
         Note that setting :attr:`data_rate` to ``Rate.ONE_SHOT`` will cause
@@ -256,23 +262,23 @@ class HTS221:  # pylint: disable=too-many-instance-attributes
         return self._data_rate
 
     @data_rate.setter
-    def data_rate(self, value):
+    def data_rate(self, value: int) -> None:
         if not Rate.is_valid(value):
             raise AttributeError("data_rate must be a `Rate`")
 
         self._data_rate = value
 
     @property
-    def humidity_data_ready(self):
+    def humidity_data_ready(self) -> bool:
         """Returns true if a new relative humidity measurement is available to be read"""
         return self._humidity_status_bit
 
     @property
-    def temperature_data_ready(self):
+    def temperature_data_ready(self) -> bool:
         """Returns true if a new temperature measurement is available to be read"""
         return self._temperature_status_bit
 
-    def take_measurements(self):
+    def take_measurements(self) -> None:
         """Update the value of :attr:`relative_humidity` and :attr:`temperature` by taking a single
         measurement. Only meaningful if :attr:`data_rate` is set to ``ONE_SHOT``"""
         self._one_shot_bit = True

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -35,7 +35,7 @@ from adafruit_register.i2c_bits import RWBits, ROBits
 from adafruit_register.i2c_bit import RWBit, ROBit
 
 try:
-    from typing import Sequence, Tuple
+    from typing import Union, Sequence, Tuple
     from busio import I2C
 except ImportError:
     pass
@@ -71,13 +71,17 @@ class CV:
     """struct helper"""
 
     @classmethod
-    def add_values(cls, value_tuples: Sequence[Tuple[str, int]]) -> None:
+    def add_values(
+        cls, value_tuples: Sequence[Tuple[str, int, Union[int, str]]]
+    ) -> None:
         """creates CV entries"""
         cls.contents = {}
+        cls.string = {}
 
         for value_tuple in value_tuples:
-            name, value = value_tuple
+            name, value, string = value_tuple
             setattr(cls, name, value)
+            cls.string[value] = string
 
     @classmethod
     def is_valid(cls, value: int) -> bool:
@@ -108,10 +112,13 @@ class Rate(CV):
 
 Rate.add_values(
     (
-        ("ONE_SHOT", 0),
-        ("RATE_1_HZ", 1),
-        ("RATE_7_HZ", 2),
-        ("RATE_12_5_HZ", 3),
+        ("ONE_SHOT", 0, 0),
+        (
+            "RATE_1_HZ",
+            1,
+        ),
+        ("RATE_7_HZ", 2, 7),
+        ("RATE_12_5_HZ", 3, 12.5),
     )
 )
 

--- a/adafruit_hts221.py
+++ b/adafruit_hts221.py
@@ -75,7 +75,6 @@ class CV:
         cls, value_tuples: Sequence[Tuple[str, int, Union[int, str]]]
     ) -> None:
         """creates CV entries"""
-        cls.contents = {}
         cls.label = {}
 
         for value_tuple in value_tuples:

--- a/examples/hts221_simpletest.py
+++ b/examples/hts221_simpletest.py
@@ -8,8 +8,12 @@ import adafruit_hts221
 i2c = board.I2C()
 hts = adafruit_hts221.HTS221(i2c)
 
+data_rate = adafruit_hts221.Rate.label[hts.data_rate]
+print("Using data rate of: {:.1f} Hz".format(data_rate))
+print("")
+
 while True:
-    print("Relative Humidity: %.2f %% rH" % hts.relative_humidity)
-    print("Temperature: %.2f C" % hts.temperature)
+    print("Relative Humidity: {:.2f} % rH".format(hts.relative_humidity))
+    print("Temperature: {:.2f} C".format(hts.temperature))
     print("")
     time.sleep(1)


### PR DESCRIPTION
Addresses Issue #9 but found some minor improvements that would make typing more clear as well as remove what seemed like unused parts of the code.  The only change from the perspective of function input and output is that `add_values()` now only needs two arguments, but that function is run by the module on import, not a user.

If its a good idea, I can try and do some more refactoring, but I didn't want to change too much for the scope of this pull request.